### PR TITLE
Fix ref and effect for compatibility with strict effect

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,14 @@ export const useDescendant = (ctx, props) => {
   const index = useRef(-1)
   const ref = useRef()
   const { list, map, force } = useContext(ctx)
-  const id = useRef(genId())
+  const id = useRef(null)
 
   useIsomorphicLayoutEffect(() => {
+    // Initialize id
+    if (id.current === null) {
+      id.current = genId()
+    }
+    
     // Do this once, on mount, so that parent map is populated ASAP
     map.current[id.current] = { ...props, _internalId: id.current }
     force({})
@@ -83,16 +88,16 @@ export const useDescendant = (ctx, props) => {
     if (ref.current) {
       ref.current.setAttribute('data-descendant', id.current)
     }
+    
+    // Keep props up to date on every render
+    if (map.current?.[id.current]) {
+      map.current[id.current] = { ...props, _internalId: id.current }
+    }
+
+    index.current = list.current.findIndex(
+      (item) => item._internalId === id.current
+    )
   })
-
-  // Keep props up to date on every render
-  if (map.current?.[id.current]) {
-    map.current[id.current] = { ...props, _internalId: id.current }
-  }
-
-  index.current = list.current.findIndex(
-    (item) => item._internalId === id.current
-  )
 
   return { index: index.current, ref, id: id.current }
 }


### PR DESCRIPTION
With React `StrictMode`, effects will be executed twice (effect → effect clean up → effect). So the `id.current = undefined` clean up will also be executed, however the ref initialization (`id = useRef(genId())`) won't be done again, so `id.current` stays `undefined`.

To fix this, we need to make the effects and effect clean ups match each other. If we have to do the clean up for `id` in an effect's return function, we need to also put its initialization in the effect body as well.