### PR TITLE
Fix `id.current` failed to re-initialize

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,11 +58,11 @@ export const useDescendant = (ctx, props) => {
   const index = useRef(-1)
   const ref = useRef()
   const { list, map, force } = useContext(ctx)
-  const id = useRef(null)
+  const id = useRef()
 
   useIsomorphicLayoutEffect(() => {
     // Initialize id
-    if (id.current === null) {
+    if (!id.current) {
       id.current = genId()
     }
     


### PR DESCRIPTION
A follow-up of #1, since we set `id.current` to `undefined` in the clean-up phase, when re-running the effect it fails to re-initialize because we only check `null` here. This PR fixes it.