### PR TITLE
fix: Avoid runtime error when there's no context

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-const DescendantContext = React.createContext({})
+const DescendantContext = React.createContext()
 const randomId = () => Math.random().toString(36).substr(2, 9)
 const noop = () => {}
 const useLayout = typeof window === 'undefined' ? noop : React.useLayoutEffect


### PR DESCRIPTION
The null check for the context here doesn't work, since context is initialized to an empty object:

https://github.com/pacocoursey/use-descendants/blob/f6c01def449c94993b1a20117cef4f3134fda744/index.js#L56

Instead, an error is thrown, since `get` is not a function.

With this PR, the context will be `undefined` and so the null check works appropriately.